### PR TITLE
Add Dockerfile

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,5 @@ spec/
 
 # gitignore file is not needed in distribution version
 .gitignore
+
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:wheezy
+MAINTAINER Dave Wittman <dave@objectrocket.com>
+
+ENV MONGODB_VERSION debian71-3.2.0
+ENV PATH /opt/mongodb/bin:${PATH}
+
+RUN apt-get update && apt-get install -y curl && \
+    curl -sL https://deb.nodesource.com/setup_5.x | bash - && \
+    apt-get install -y nodejs && \
+    mkdir -p /opt/mongodb && \
+    curl -sL https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB_VERSION}.tgz | tar xz -C /opt/mongodb --strip-components=1 && \
+    npm install -g variety-cli && \
+    npm cache clear && \
+    apt-get remove -y curl && \
+    rm /opt/mongodb/bin/mongo?* /opt/mongodb/bin/bson* && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["/usr/bin/variety"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,32 @@ of *variety-cli* directly from the [github repository of Variety](https://raw.gi
 
 If you want to upgrade *variety-cli* to newest version, type the same command as for the installation: ```npm install variety-cli -g```.
 
+### Docker
+
+You can also run **variety-cli** in Docker using a pre-built image in Docker Hub. In this case, you'll generally want to run Variety against an external MongoDB host with the `--host` flag. See the example below for more information.
+
+The **variety-cli** image is tagged in Docker Hub as [objectrocket/variety](https://hub.docker.com/r/objectrocket/variety/), which you can run as follows:
+
+```
+docker run objectrocket/variety test/foo --host db.example.com --quiet
+```
+
+Any arguments after the image name are passed to **variety-cli**, just as if you were running it directly from the command-line.
+
+#### Manually building the Docker image
+
+First, build the image with `docker build`:
+
+```
+docker build -t variety .
+```
+
+This will build a Docker image tagged locally as `variety`, which you can run with:
+
+```
+docker run variety test/foo --host db.example.com --quiet
+```
+
 ## Proxy setting
 
 If you are behind some proxy, you should configure proxy setting in your environment (to allow variety-cli download of the variety lib).


### PR DESCRIPTION
This adds a Dockerfile for `variety-cli`. I currently have the repository stored in [Docker Hub](https://hub.docker.com/r/objectrocket/variety/) at `objectrocket/variety`, which allows one to execute using Docker as follows:

```
$ docker run objectrocket/variety test/foo --host db.example.com --quiet --persistResults=true
```
