### PR TITLE
Dependencies update + simplification, short arguments support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
     "env": {
         "node": true,
+        "es6": true,
         "jasmine": true
     },
     "extends": "eslint:recommended",

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 # intellij idea project files
 .idea/
-
-# variety.js should not be part of the repository, will be downloaded automatically
-variety.js
+*.iml
 
 # Node.js dependencies
 node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "5"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,5 @@
 environment:
   matrix:
-    - nodejs_version: "0.11"
-    - nodejs_version: "0.12"
-    - nodejs_version: "3"
     - nodejs_version: "4"
     - nodejs_version: "5"
 install:

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var Q = require('q');
 var child = require('child-process-promise');
 var program = require('./program');
 var utils = require('./utils');
@@ -19,11 +18,11 @@ var executeVariety = function(proc, args, libPath) {
 };
 
 var parse = function(proc) {
-  return Q.resolve(program.parse(proc.argv));
+  return Promise.resolve(program.parse(proc.argv));
 };
 
 var shouldRunAnalysis = function(args) {
-  return (args.params.help || !args.db || !args.collection) ? Q.reject() : Q.resolve(args);
+  return (args.params.help || !args.db || !args.collection) ? Promise.reject() : Promise.resolve(args);
 };
 
 var printHelp = function(proc, ex) {
@@ -45,7 +44,7 @@ module.exports = function(proc) {
         .then(function(){return verifyVarietyLib(proc);})
         .then(function(libPath){return executeVariety(proc, args, libPath);});
     })
-  .fail(function(ex) {
+  .catch(function(ex) {
     printHelp(proc, ex);
   });
 };

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,22 +3,31 @@
 var child = require('child-process-promise');
 var program = require('./program');
 var utils = require('./utils');
+var colors = require('colors/safe');
 
 var executeVariety = function(proc, args, libPath) {
   var spawnArgs = [args.db, '--eval='+utils.buildParams(args.collection, args.params), libPath].concat(args.shellParams);
-  return child.spawn('mongo', spawnArgs)
-    .progress(function (childProcess) {
-      childProcess.stdout.on('data', function (data) {
-        proc.stdout.write(data.toString());
-      });
-      childProcess.stderr.on('data', function (data) {
-        proc.stderr.write(data.toString());
-      });
-    });
+
+  var promise = child.spawn('mongo', spawnArgs);
+
+  var childProcess = promise.childProcess;
+  childProcess.stdout.on('data', function (data) {
+    proc.stdout.write(data.toString());
+  });
+  childProcess.stderr.on('data', function (data) {
+    proc.stderr.write(data.toString());
+  });
+
+  return promise;
+
 };
 
 var parse = function(proc) {
-  return Promise.resolve(program.parse(proc.argv));
+  try {
+    return Promise.resolve(program.parse(proc.argv));
+  } catch (err) {
+    return Promise.reject(err);
+  }
 };
 
 var shouldRunAnalysis = function(args) {
@@ -27,9 +36,17 @@ var shouldRunAnalysis = function(args) {
 
 var printHelp = function(proc, ex) {
   if(ex) {
-    proc.stderr.write(ex.message);
+    var errText = '\nERROR: ' + ex.message + '\n\n';
+    proc.stderr.write(colors.red.bold(errText));
   }
-  proc.stdout.write(program.help());
+  var helpText = program.help();
+  proc.stdout.write(helpText);
+
+  if(ex) {
+    return Promise.reject(ex);
+  } else {
+    return Promise.resolve(helpText);
+  }
 };
 
 var verifyVarietyLib = function() {
@@ -45,6 +62,6 @@ module.exports = function(proc) {
         .then(function(libPath){return executeVariety(proc, args, libPath);});
     })
   .catch(function(ex) {
-    printHelp(proc, ex);
+    return printHelp(proc, ex);
   });
 };

--- a/lib/program.js
+++ b/lib/program.js
@@ -8,9 +8,17 @@ var _ = require('lodash');
 
 var opt = function(name, desc, parser) { return {'name':name, 'desc':desc, 'parser':parser};};
 
+var parseHson = function(input) {
+  try {
+    return HJSON.parse(input);
+  } catch (e) {
+    throw new Error('Failed to parse option \''+this.name+'\': ' + e.message);
+  }
+};
+
 var options = [
-  opt('query',          'standard Mongo query object (json), to filter the set of documents required before analysis', HJSON.parse),
-  opt('sort',           'analyze documents in the specified order, takes Mongo sort object (json)', HJSON.parse),
+  opt('query',          'standard Mongo query object (json), to filter the set of documents required before analysis', parseHson),
+  opt('sort',           'analyze documents in the specified order, takes Mongo sort object (json)', parseHson),
   opt('maxDepth',       'limit the <n> depth Variety will recursively search to find new objects', parseInt),
   opt('limit',          'analyze only the <n> newest documents in a collection', parseInt),
   opt('outputFormat',   'output format of results, possible variants are "ascii" or "json", default is "ascii"', String),
@@ -41,7 +49,11 @@ var parseVarietyArgs = function(options, args) {
 var parseMongoArgs = function(options, args) {
   var unknownOpts = parsedOpts(options, args).filter(function(opt){return !opt.def && opt.name != '_';});
   var accumulate = function(acc, opt) {
-    acc.push('--' + opt.name);
+    if(opt.name.length > 1) {
+      acc.push('--' + opt.name);
+    } else {
+      acc.push('-' + opt.name);
+    }
     if(typeof opt.value !== 'boolean') {
       acc.push(opt.value);
     }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "child-process-promise": "^2.0.1",
+    "colors": "^1.1.2",
     "hjson": "^1.6.3",
     "lodash": "^4.6.1",
     "minimist": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,10 @@
     "url": "https://github.com/variety/variety-cli/issues"
   },
   "dependencies": {
-    "minimist": "^1.1.1",
+    "child-process-promise": "^2.0.1",
     "hjson": "^1.6.3",
-    "q": "^1.3.0",
     "lodash": "^4.6.1",
-    "child-process-promise": "^1.0.2",
+    "minimist": "^1.1.1",
     "variety": "variety/variety"
   },
   "devDependencies": {
@@ -41,5 +40,8 @@
     "pretest": "npm run lint",
     "test": "istanbul cover -x **/spec/** jasmine-node -- spec --verbose --captureExceptions",
     "coverage": "cat ./coverage/lcov.info | coveralls"
+  },
+  "engines": {
+    "node": ">=4"
   }
 }

--- a/spec/cli_spec.js
+++ b/spec/cli_spec.js
@@ -1,5 +1,4 @@
 var cli = require('../lib/cli');
-var Q = require('q');
 
 var getWritableStream = function() {
   var Writable = require('stream').Writable;
@@ -13,7 +12,10 @@ var getWritableStream = function() {
 };
 
 var mockSpawn = function(bin, args) {
-  return Q.resolve({'bin':bin, 'args':args});
+  var promise = Promise.resolve({'bin':bin, 'args':args});
+  // mock progress interface
+  promise.progress = function() {return this;};
+  return promise;
 };
 
 describe(__filename, function () {
@@ -35,11 +37,10 @@ describe(__filename, function () {
       argv:   ['node', 'variety-cli.js', '--help'],
       process: null
     })
-    .fin(function(){
+    .then(function(){
       expect(ws.content).toContain('Usage: variety db_name/collection_name [options]');
       done();
-    })
-    .done();
+    });
   });
 
   it('CLI should correctly execute Variety', function (done) {
@@ -65,6 +66,6 @@ describe(__filename, function () {
       expect(res.args[4]).toEqual('localhost'); //library path
       done();
     })
-    .done();
+    .catch(done);
   });
 });

--- a/spec/cli_spec.js
+++ b/spec/cli_spec.js
@@ -13,8 +13,12 @@ var getWritableStream = function() {
 
 var mockSpawn = function(bin, args) {
   var promise = Promise.resolve({'bin':bin, 'args':args});
-  // mock progress interface
-  promise.progress = function() {return this;};
+
+  promise.childProcess = {
+    stdout:{on:function(){}},
+    stderr:{on:function(){}}
+  };
+
   return promise;
 };
 
@@ -68,4 +72,87 @@ describe(__filename, function () {
     })
     .catch(done);
   });
+
+  it('CLI should forward auth arguments directly to mongo shell', function (done) {
+
+    var child = require('child-process-promise');
+
+    spyOn(child, 'spawn').andCallFake(mockSpawn);
+
+    var ws = getWritableStream();
+    cli({
+      stdout: ws,
+      stderr: ws,
+      exitFn: function(){},
+      argv:   ['node', 'variety-cli.js', 'foo/bar', '--username', 'lorem', '--password', 'ipsum', '--authenticationDatabase', 'my-auth-db'],
+      process: null
+    })
+    .then(function(res) {
+      expect(res.bin).toEqual('mongo');
+      expect(res.args[0]).toEqual('foo'); //db name
+      expect(res.args[1]).toEqual('--eval=var collection="bar";'); //variety args
+      expect(res.args[2]).toEndWith('variety.js'); //library path
+      expect(res.args[3]).toEqual('--username');
+      expect(res.args[4]).toEqual('lorem');
+      expect(res.args[5]).toEqual('--password');
+      expect(res.args[6]).toEqual('ipsum');
+      expect(res.args[7]).toEqual('--authenticationDatabase');
+      expect(res.args[8]).toEqual('my-auth-db');
+      done();
+    })
+    .catch(done);
+  });
+
+  it('CLI should handle short versions of mongo arguments (for example -u, -p)', function (done) {
+
+    var child = require('child-process-promise');
+
+    spyOn(child, 'spawn').andCallFake(mockSpawn);
+
+    var ws = getWritableStream();
+    cli({
+      stdout: ws,
+      stderr: ws,
+      exitFn: function(){},
+      argv:   ['node', 'variety-cli.js', 'foo/bar', '-u', 'lorem', '-p', 'ipsum', '--authenticationDatabase', 'my-auth-db'],
+      process: null
+    })
+    .then(function(res) {
+      expect(res.bin).toEqual('mongo');
+      expect(res.args[0]).toEqual('foo'); //db name
+      expect(res.args[1]).toEqual('--eval=var collection="bar";'); //variety args
+      expect(res.args[2]).toEndWith('variety.js'); //library path
+      expect(res.args[3]).toEqual('-u');
+      expect(res.args[4]).toEqual('lorem');
+      expect(res.args[5]).toEqual('-p');
+      expect(res.args[6]).toEqual('ipsum');
+      expect(res.args[7]).toEqual('--authenticationDatabase');
+      expect(res.args[8]).toEqual('my-auth-db');
+      done();
+    })
+    .catch(done);
+  });
+
+  it('CLI should handle incorrect args and print error + help', function (done) {
+
+    var child = require('child-process-promise');
+    spyOn(child, 'spawn').andCallFake(mockSpawn);
+
+    var ws = getWritableStream();
+    cli({
+      stdout: ws,
+      stderr: ws,
+      exitFn: function(){},
+      argv:   ['node', 'variety-cli.js', 'foo/bar', '--sort', '{foo:bar)'], // incorrect brackets pair
+      process: null
+    })
+    .then(function() {
+      done(new Error('Should throw exception and continue in catch branch'));
+    })
+    .catch(function(err) {
+      expect(err.message).toContain('Failed to parse option');
+      done();
+    });
+  });
+
 });

--- a/variety-cli.js
+++ b/variety-cli.js
@@ -9,4 +9,4 @@ cli({
   exitFn: process.exit,
   argv:   process.argv,
   process: process
-}).done(); // end the promise
+});


### PR DESCRIPTION
This PR updates _child-process-promise_ dependency, which brings the need of node version >= 4. I believe it's better to have up-to-date dependencies even when dropping old versions of node. New version of node brings us native Promises and more ES6 features. 

Short arguments support is added and tested. Tests are closely related to the Promise interface, so it should probably go along in the same PR.
