### PR TITLE
Add support for connection strings.

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -67,7 +67,7 @@ var parseDbCollection = function(args) {
   var db = null;
   var collection = null;
   if(args._.length > 0) {
-    var split = args._[0].split('/')
+    var split = args._[0].split('/');
     
     db = split.slice(0, split.length - 1).join('/');
     collection = split[split.length - 1];

--- a/lib/program.js
+++ b/lib/program.js
@@ -66,9 +66,11 @@ var parseMongoArgs = function(options, args) {
 var parseDbCollection = function(args) {
   var db = null;
   var collection = null;
-  if(args._.length > 0 && args._[0].split('/').length == 2) {
-    db = args._[0].split('/')[0];
-    collection = args._[0].split('/')[1];
+  if(args._.length > 0) {
+    var split = args._[0].split('/')
+    
+    db = split.slice(0, split.length - 1).join('/');
+    collection = split[split.length - 1];
   }
   return {'db':db, 'collection':collection};
 };


### PR DESCRIPTION
I Liked this package but needed support for connection strings, so I've made a small change to the db collection parser so it also accepts connection strings. 

usage:
`node variety-cli.js <connectionString>/<collection> <options>`

Should have no impact on existing workflows, validation is probably a bit less strict though. If you think it's a good addition to variety, let me know and I'll improve the PR, otherwise feel free to do with it what you like ;)